### PR TITLE
add server_cloak mod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -485,3 +485,6 @@
 [submodule "pipeworks_elbow"]
 	path = pipeworks_elbow
 	url = https://github.com/mt-mods/pipeworks_elbow.git
+[submodule "server_cloak"]
+	path = server_cloak
+	url = https://github.com/pandorabox-io/server_cloak


### PR DESCRIPTION
## Overview

This PR will add the `server_cloak` mod.
It disables the announcement to the global serverlist if the player-count exceeds 15.

## Goals

Reduce the number of newcomers if the server has reached a certain "load".
That way all the "regulars" that have the address in the bookmarks or know the name/port
can still join.

## Adjustments

The threshold can be adjusted or the mod removed if it turns out to be a total mistake :smile:

## Feedback / Reality-Check

@OgelGames @SwissalpS @coil0 @int-ua Any objections / suggestions?