### PR TITLE
add digiline routing module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -499,3 +499,6 @@
 [submodule "metatool"]
 	path = metatool
 	url = https://github.com/S-S-X/metatool.git
+[submodule "digiline_routing"]
+	path = digiline_routing
+	url = https://github.com/numberZero/digiline_routing.git


### PR DESCRIPTION
this adds the `digiline_routing` mod, which brings:
* diode
* filter
* spliter

for digiline-signals

Repo: https://github.com/numberZero/digiline_routing

Merging the next day when there are no objections..
@Lejo1 thanks for testing
@S-S-X thanks for recommending