### PR TITLE
add pipeworks_item_expiration mod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -528,3 +528,6 @@
 [submodule "monitoring_advtrains"]
 	path = monitoring_advtrains
 	url = https://github.com/minetest-monitoring/monitoring_advtrains.git
+[submodule "pipeworks_item_expiration"]
+	path = pipeworks_item_expiration
+	url = https://github.com/BuckarooBanzay/pipeworks_item_expiration.git


### PR DESCRIPTION
adds https://github.com/BuckarooBanzay/pipeworks_item_expiration
which removes items that are longer in the pipes than 10 minutes

should fix the problem with constant pipeworks-lag from items that don't get sorted properly and never arrive (around 10% globalstep average)