### PR TITLE
add dreambuilder_hotbar mod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -143,6 +143,9 @@
 [submodule "drawers"]
 	path = drawers
 	url = https://github.com/minetest-mods/drawers.git
+[submodule "dreambuilder_hotbar"]
+	path = dreambuilder_hotbar
+	url = https://gitlab.com/VanessaE/dreambuilder_hotbar.git
 [submodule "easyvend"]
 	path = easyvend
 	url = https://github.com/minetest-mirrors/easyvend.git


### PR DESCRIPTION
Adds the `dreambuilder_hotbar` mod (https://gitlab.com/VanessaE/dreambuilder_hotbar)

The following Settings-PR sets the default slots to 8:
https://github.com/pandorabox-io/pandorabox.io/pull/597

## Performance/Lag/Backwards-compatibility
This change should have no impact lag-wise or UI-wise and is opt-in only (`/hudbar [8|16|32]`)

@wsor4035 @OgelGames