### PR TITLE
Add digicontrol mod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -539,3 +539,6 @@
 [submodule "blockexchange"]
 	path = blockexchange
 	url = https://github.com/blockexchange/blockexchange
+[submodule "digicontrol"]
+	path = digicontrol
+	url = https://github.com/OgelGames/digicontrol


### PR DESCRIPTION
This PR adds the `digicontrol` mod, a replacement for the `digiline_routing` mod.

https://github.com/OgelGames/digicontrol

**Advantages over `digiline_routing`**

- All components are contained within single nodes.
- Doesn't duplicate digiline messages.
- Less overhead due to no overheating code.
- None of the other bugs `digiline_routing` has. (pandorabox-io/pandorabox.io#553)
- Additional Limiter and Tri-Splitter nodes. 

Once this is added and tested, `digiline_routing` can be removed and it's nodes will automatically be replaced.

@BuckarooBanzay @S-S-X @SwissalpS @Lejo1