### PR TITLE
add pick_axe_tweaks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -542,3 +542,6 @@
 [submodule "digicontrol"]
 	path = digicontrol
 	url = https://github.com/OgelGames/digicontrol
+[submodule "pick_axe_tweaks"]
+	path = pick_axe_tweaks
+	url = https://github.com/wsor4035/pick_axe_tweaks.git


### PR DESCRIPTION
what the title says, this mod allows pick axes on right click to place a light node of there choosing (by default the torch) or disable the functionality completely. it also does *not* place the light node if the pointed node itself has a on rightclick however this can be overridden by holding down sneak.