### PR TITLE
Update TPR to new location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -482,7 +482,7 @@
 	url = https://github.com/lisacvuk/minetest-toolranks.git
 [submodule "tpr"]
 	path = tpr
-	url = https://github.com/ChaosWormz/teleport-request
+	url = https://github.com/minetest-mods/teleport-request
 [submodule "travelnet"]
 	path = travelnet
 	url = https://github.com/mt-mods/travelnet.git


### PR DESCRIPTION
Things added/changed:

- Update [TPR](https://github.com/minetest-mods/teleport-request) to its new location.
  - [TPR](https://github.com/minetest-mods/teleport-request) was moved to [Minetest Mods](https://github.com/minetest-mods) some weeks ago.
