### PR TITLE
Add basic streets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -567,3 +567,6 @@
 [submodule "digiline_craftdb"]
 	path = digiline_craftdb
 	url = https://github.com/dennisjenkins75/digiline_craftdb
+[submodule "basic_streets"]
+	path = basic_streets
+	url = https://github.com/BuckarooBanzay/basic_streets.git


### PR DESCRIPTION
This adds the `basic_streets` mod (https://github.com/BuckarooBanzay/basic_streets)

![](https://raw.githubusercontent.com/BuckarooBanzay/basic_streets/master/screenshot.png)

Features:
* tar blocks with markings (colorable, rotateable, sawable)
* player speed increases on tar nodes (factor 1.5, only if not in `fly` mode)