### PR TITLE
Remove `fsc` mod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -193,9 +193,6 @@
 [submodule "framedglass"]
 	path = framedglass
 	url = https://github.com/minetest-mods/framedglass.git
-[submodule "fsc"]
-	path = fsc
-	url = https://github.com/sofar/fsc.git
 [submodule "geocache"]
 	path = geocache
 	url = https://github.com/pandorabox-io/geocache.git


### PR DESCRIPTION
Currently `fsc` is only optionally used by the `inspector` mod, which doesn't even have any formspec handlers:
```lua
local fsc_modpath = minetest.get_modpath("fsc")
local function show_formspec(player_name, formspec)
	if fsc_modpath then
		fsc.show(player_name, formspec, {}, function() end)
	else
		-- none of Inspector's formspecs have player response handlers, so
		-- the name doesn't really matter.
		minetest.show_formspec(player_name, "inspector:formspec", formspec)
	end
end
```
https://github.com/minetest-mods/inspector/blob/dea86186d0dffee2285c546ae33d3cef92b5b8c0/init.lua#L13-L22

So there are zero downsides to removing the mod, but the benefit of one less mod being loaded.