### PR TITLE
add metadata_cache mod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -585,3 +585,6 @@
 [submodule "mtzip"]
 	path = mtzip
 	url = https://github.com/BuckarooBanzay/mtzip.git
+[submodule "metadata_cache"]
+	path = metadata_cache
+	url = https://github.com/minetest-monitoring/metadata_cache


### PR DESCRIPTION
simple "write-through" cache for `minetest.get_meta`
https://github.com/minetest-monitoring/metadata_cache/blob/master/init.lua

Caches all reads on the lua-side and passes writes through to the engine
The cache gets purged periodically (every minute)

**NOTE**: Live on the test-server, will merge on the next maintenance-window/crash/whenever-it-fits :shrug: 