### PR TITLE
add metadata_cache mod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -585,3 +585,6 @@
 [submodule "mtzip"]
 	path = mtzip
 	url = https://github.com/BuckarooBanzay/mtzip.git
+[submodule "metadata_cache"]
+	path = metadata_cache
+	url = https://github.com/minetest-monitoring/metadata_cache


### PR DESCRIPTION
![eye-roll-ugh](https://user-images.githubusercontent.com/39065740/198367546-5d26f292-32d3-4511-9640-4aa28fcca2c2.gif)

Adds the `metadata_cache` mod (again)
https://github.com/minetest-monitoring/metadata_cache

New stuff:
* testing (yay) with some edge-cases i found
* various fixes

Tested it on the `test.pandorabox.io` server (setup at spawn)
* `technic_cnc` doesn't crash and works
* `digtron` pack and unpack works