### PR TITLE
add the `digibuilder` mod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -588,3 +588,6 @@
 [submodule "metadata_cache"]
 	path = metadata_cache
 	url = https://github.com/minetest-monitoring/metadata_cache
+[submodule "digibuilder"]
+	path = digibuilder
+	url = https://github.com/BuckarooBanzay/digibuilder


### PR DESCRIPTION
This PR adds the `digibuilder` mod, for more infos see: https://github.com/BuckarooBanzay/digibuilder

In short: A new digiline-enabled node that allows the player to:
* query in-world node-names (in a predefined range around the node, 15 nodes per default)
* place nodes into the world (only "normal" and `facedir` types, they are taken from the node-inventory)

Use-cases:
* Duplicators
* Procedural/Programmatic building

as always: reality-checks/suggestions/criticism welcome